### PR TITLE
[packaging] Require libhardware with pkgconfig so hw specific libhybris ...

### DIFF
--- a/rpm/mce-plugin-libhybris.spec
+++ b/rpm/mce-plugin-libhybris.spec
@@ -15,8 +15,7 @@ Requires(preun):  systemd
 Requires(postun): systemd
 
 BuildRequires:  pkgconfig(glib-2.0) >= 2.18.0
-BuildRequires:  libhybris-devel
-BuildRequires:  libhybris-libhardware-devel
+BuildRequires:  pkgconfig(libhardware)
 BuildRequires:  systemd
 
 %description


### PR DESCRIPTION
...builds can be used easily.

Signed-off-by: Marko Saukko marko.saukko@jollamobile.com
