### PR TITLE
Use sysfs for indicator led control to allow blinking

### DIFF
--- a/hybris.c
+++ b/hybris.c
@@ -675,6 +675,12 @@ static void led_control(int chn, int val, int on, int off)
   if( val > m ) val = m;
   if( val < 0 ) val = 0;
 
+  if( val != 0 ) {
+    write_number(led_paths[chn].on,  0);
+    write_number(led_paths[chn].off, 0);
+    write_number(led_paths[chn].val, 0);
+  }
+
   write_number(led_paths[chn].on,  on);
   write_number(led_paths[chn].off, off);
   write_number(led_paths[chn].val, val);


### PR DESCRIPTION
If red, green and blue channels are found from sysfs, those are
used for led control instead of the libhardware functions.
